### PR TITLE
libc: strlen in assembler approach for i386

### DIFF
--- a/libc/string/strlen.c
+++ b/libc/string/strlen.c
@@ -1,10 +1,21 @@
 #include <string.h>
 
 size_t
-strlen(const char* string)
+strlen( const char* s_ptr )
 {
     size_t result = 0;
-    while ( string[result] )
-        result++;
+
+    __asm__ __volatile__ ( "  \
+        mov $1, %%ecx;        \
+        neg %%ecx;            \
+        xor %%eax, %%eax;     \
+        cld; repne scasb;     \
+        neg %%ecx;            \
+        sub $2, %%ecx;        \
+        mov %%ecx, (%[POS]);"
+        : "+D" ( s_ptr )
+        : [POS] "r" ( &result )
+    );
+
     return result;
 }


### PR DESCRIPTION
A common use of the REPNE SCASB instruction is to find the length of a NUL-terminated string. Here is an example:

        MOV     DI, DX          ;Starting address in DX (assume ES = DS)
        MOV     AL, 0           ;Byte to search for (NUL)
        MOV     CX, -1          ;Start count at FFFFh
        CLD                     ;Increment DI after each character
        REPNE SCASB             ;Scan string for NUL, decrementing CX for each char
        MOV     AX, -2          ;CX will be -2 for length 0, -3 for length 1, ...
        SUB     AX, CX          ;Length in AX

https://www.csc.depauw.edu/~bhoward/asmtut/asmtut7.html