### PR TITLE
libc: memmove in assembler approach for i386

### DIFF
--- a/libc/string/memmove.c
+++ b/libc/string/memmove.c
@@ -1,15 +1,47 @@
 #include <string.h>
 
-void*
-memmove(void* dstptr, const void* srcptr, size_t size)
+#define __PACK_CHUNK_OFFSET(S, AS)   ( S << AS )
+#define __PACK_CALC_NUMBER(L, AS)    ( L >> AS )
+#define __PACK_SIZE(AS)              ( __PACK_CHUNK_OFFSET(1, AS) )
+#define __PACK_MAX_REMANENT(AS)      ( __PACK_SIZE(AS) - 1 )
+#define __PACK_CALC_REMANENT(L, AS)  ( L & __PACK_MAX_REMANENT(AS) )
+#define __PACK_EDGE_ADDR(P, S, AS)   ( (void *)((size_t)P + __PACK_CHUNK_OFFSET(S, AS)) )
+#define __PACK_CHECK_PTR(P, AS)      ( (size_t)P % __PACK_SIZE(AS) == 0 )
+
+#define PACK_32_SHIFT              2
+#define PACK_32_CHUNK_OFFSET(S)   __PACK_CHUNK_OFFSET(S, PACK_32_SHIFT)
+#define PACK_32_CALC_NUMBER(L)    __PACK_CALC_NUMBER(L, PACK_32_SHIFT)
+#define PACK_32_SIZE              __PACK_SIZE(PACK_32_SHIFT)
+#define PACK_32_CALC_REMANENT(L)  __PACK_CALC_REMANENT(L, PACK_32_SHIFT)
+#define PACK_32_EDGE_ADDR(P, S)   __PACK_EDGE_ADDR(P, S, PACK_32_SHIFT)
+#define PACK_32_CHECK_PTR(P)      __PACK_CHECK_PTR(P, PACK_32_SHIFT)
+
+
+extern void *
+memmove( void* dst_ptr, const void* src_ptr, size_t len )
 {
-    unsigned char* dst = (unsigned char*) dstptr;
-    const unsigned char* src = (const unsigned char*) srcptr;
-    if ( dst < src )
-        for ( size_t i = 0; i < size; i++ )
-            dst[i] = src[i];
+    size_t chunks = 0;
+
+    if ( PACK_32_CHECK_PTR( src_ptr ) && PACK_32_CHECK_PTR( dst_ptr ) )
+    {
+        chunks = PACK_32_CALC_NUMBER( len );
+        __asm__ __volatile__ ( "\
+            cld; rep; movsd;    \
+            mov %3,%0;          \
+            rep; movsb;"
+            : "+c" ( chunks ), "+S" ( src_ptr ), "+D" ( dst_ptr )
+            : "r" ( PACK_32_CALC_REMANENT( len ) )
+        );
+    }
     else
-        for ( size_t i = size; i != 0; i-- )
-            dst[i-1] = src[i-1];
-    return dstptr;
+    {
+        __asm__ __volatile__ ( "\
+            cld; rep; movsb;"
+            : "+c" ( len ), "+S" ( src_ptr ), "+D" ( dst_ptr )
+            :
+        );
+
+    }
+
+    return dst_ptr;
 }


### PR DESCRIPTION
This code was previously utilized for memcpy.
As of now, we are gonna start calling memmove as the engine of memcpy