### PR TITLE
libc: memcpy calling memmove code

### DIFF
--- a/libc/string/memcpy.c
+++ b/libc/string/memcpy.c
@@ -1,21 +1,5 @@
 #include <string.h>
 
-#define __PACK_CHUNK_OFFSET(S, AS)   ( S << AS )
-#define __PACK_CALC_NUMBER(L, AS)    ( L >> AS )
-#define __PACK_SIZE(AS)              ( __PACK_CHUNK_OFFSET(1, AS) )
-#define __PACK_MAX_REMANENT(AS)      ( __PACK_SIZE(AS) - 1 )
-#define __PACK_CALC_REMANENT(L, AS)  ( L & __PACK_MAX_REMANENT(AS) )
-#define __PACK_EDGE_ADDR(P, S, AS)   ( (void *)((size_t)P + __PACK_CHUNK_OFFSET(S, AS)) )
-#define __PACK_CHECK_PTR(P, AS)      ( (size_t)P % __PACK_SIZE(AS) == 0 )
-
-#define PACK_32_SHIFT              2
-#define PACK_32_CHUNK_OFFSET(S)   __PACK_CHUNK_OFFSET(S, PACK_32_SHIFT)
-#define PACK_32_CALC_NUMBER(L)    __PACK_CALC_NUMBER(L, PACK_32_SHIFT)
-#define PACK_32_SIZE              __PACK_SIZE(PACK_32_SHIFT)
-#define PACK_32_CALC_REMANENT(L)  __PACK_CALC_REMANENT(L, PACK_32_SHIFT)
-#define PACK_32_EDGE_ADDR(P, S)   __PACK_EDGE_ADDR(P, S, PACK_32_SHIFT)
-#define PACK_32_CHECK_PTR(P)      __PACK_CHECK_PTR(P, PACK_32_SHIFT)
-
 
 //!============================================================================
 //!
@@ -40,28 +24,5 @@
 extern void *
 memcpy( void * restrict dst_ptr, const void * restrict src_ptr, size_t len )
 {
-    size_t chunks = 0;
-
-    if ( PACK_32_CHECK_PTR( src_ptr ) && PACK_32_CHECK_PTR( dst_ptr ) )
-    {
-        chunks = PACK_32_CALC_NUMBER( len );
-        __asm__ __volatile__ ( "\
-            cld; rep; movsd;    \
-            mov %3,%0;          \
-            rep; movsb;"
-            : "+c" ( chunks ), "+S" ( src_ptr ), "+D" ( dst_ptr )
-            : "r" ( PACK_32_CALC_REMANENT( len ) )
-        );
-    }
-    else
-    {
-        __asm__ __volatile__ ( "\
-            cld; rep; movsb;"
-            : "+c" ( len ), "+S" ( src_ptr ), "+D" ( dst_ptr )
-            :
-        );
-
-    }
-
-    return dst_ptr;
+    return memmove( dst_ptr, src_ptr, len );
 }


### PR DESCRIPTION
The unique difference between memcpy and memmove is The memory areas may overlap in the second one.
So memcpy is just  a memmove implementation with restrict attributes upon their pointers :)