### PR TITLE
include: common limits and common type headers

### DIFF
--- a/include/machine/limits.h
+++ b/include/machine/limits.h
@@ -1,5 +1,5 @@
-#ifndef __LIMITS_H__
-#define	__LIMITS_H__
+#ifndef __MACHINE_LIMITS_H__
+#define	__MACHINE_LIMITS_H__
 
 #if defined (__x86__)
 #include "x86/types.h"
@@ -7,4 +7,4 @@
 #error architecture not supported
 #endif
 
-#endif  /* __LIMITS_H__ */
+#endif  /* __MACHINE_LIMITS_H__ */

--- a/include/machine/limits.h
+++ b/include/machine/limits.h
@@ -1,0 +1,10 @@
+#ifndef __LIMITS_H__
+#define	__LIMITS_H__
+
+#if defined (__x86__)
+#include "x86/types.h"
+#else
+#error architecture not supported
+#endif
+
+#endif  /* __LIMITS_H__ */

--- a/include/machine/types.h
+++ b/include/machine/types.h
@@ -1,0 +1,10 @@
+#ifndef __MACHINE_TYPES_H__
+#define	__MACHINE_TYPES_H__
+
+#if defined (__x86__)
+#include "x86/types.h"
+#else
+#error architecture not supported
+#endif
+
+#endif  /* __MACHINE_TYPES_H__ */

--- a/include/x86/limits.h
+++ b/include/x86/limits.h
@@ -1,0 +1,27 @@
+#ifndef __X86_LIMITS_H__
+#define __X86_LIMITS_H__
+
+#define	SCHAR_MAX     127                 /* min value for a signed char */
+#define	SCHAR_MIN     ( -128 )            /* max value for a signed char */
+
+#define	UCHAR_MAX     255                 /* max value for an unsigned char */
+#define	CHAR_MAX      SCHAR_MAX           /* max value for a char */
+#define	CHAR_MIN      SCHAR_MIN           /* min value for a char */
+
+#define	USHRT_MAX     65535               /* max value for an unsigned short */
+#define	SHRT_MAX      32767               /* max value for a short */
+#define	SHRT_MIN      ( -32768 )          /* min value for a short */
+
+#define	UINT_MAX      0xffffffffU         /* max value for an unsigned int */
+#define	INT_MAX       2147483647          /* max value for an int */
+#define	INT_MIN       ( -INT_MAX-1 )     /* min value for an int */
+
+#define	ULONG_MAX     0xffffffffUL        /* max value for an unsigned long */
+#define	LONG_MAX      2147483647L         /* max value for a long */
+					  /* min value for a long */
+#define	LONG_MIN      ( -2147483647L-1L )
+
+#define	SSIZE_MAX     INT_MAX             /* max value for a ssize_t */
+#define	SIZE_T_MAX    UINT_MAX            /* max value for a size_t */
+
+#endif  /* __X86_LIMITS_H__ */

--- a/include/x86/types.h
+++ b/include/x86/types.h
@@ -1,0 +1,11 @@
+#ifndef __X86_TYPES_H__
+#define __X86_TYPES_H__
+
+typedef	signed char	   int8_t;
+typedef	unsigned char	  uint8_t;
+typedef	short		  int16_t;
+typedef	unsigned short	 uint16_t;
+typedef	int		  int32_t;
+typedef	unsigned int	 uint32_t;
+
+#endif  /* __X86_TYPES_H__ */


### PR DESCRIPTION
This headers shall be common upon user and kernel space code.
As it is shown machine directory deals with arch details.

Such headers shall be useful if the overall of the stdint.h
references in this operative system are removed.

Signed-off-by: Bob Ross <pianodaemon@gmail.com>