### PR TITLE
load next sector(s) macro

### DIFF
--- a/boot/boot.S
+++ b/boot/boot.S
@@ -9,11 +9,15 @@ start:
 	mov %ax, %ds
 	mov %ax, %es
 	mov %ax, %ss
+	mov %dl, init_dl // save boot drive
+init_dl: .byte 0
 
 	CLEAN
 	RESET_CURSOR
 	PRINT_STR $start_msg, $11
 	PRINT_STR $gdt_msg, $11
+	LOAD_NSECTOR $1
+
 	lgdt gdtdesc
 
 	PRINT_STR $protecte_msg, $23

--- a/boot/boot.h
+++ b/boot/boot.h
@@ -37,3 +37,16 @@
         jmp 1b
 2:
 .endm
+
+.macro LOAD_NSECTOR s
+        mov $0x02, %ah     // function:2 read sectors from disk drive
+        mov \s, %al        // number of sector to read
+        mov $0x00, %dh     // head: 0
+        mov init_dl, %dl   // recall boot drive number
+        mov $0002, %cx     // cylinder:0 sector:2
+        mov  $1f, %bx      // buffer address pointer es:bx
+        int  $0x13         // low level disk services
+        jmp  1f
+        .section .nsector
+1:
+.endm // cf set on error; ah return code; al actual sectors verfied count

--- a/boot/boot.ld
+++ b/boot/boot.ld
@@ -7,5 +7,9 @@ SECTIONS
 		*(.text)
 		. = 0x1FE;
 		SHORT(0xAA55)
+		*(.nsector)
+		. = ALIGN(512);
+		__end = .;
+		__end_align_4k = ALIGN(4k);
 	}
 }


### PR DESCRIPTION
The LOAD_NSECTOR macro will bring 's' number of sectors to memory
and it will jump to them. Watch out when loading several sectors
to not trespass segment limits (0x10000 or 64k)