### PR TITLE
Add no-pie flag, change optimiaztion level to 0, add debug rule

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -4,12 +4,13 @@ all: kernel.bin
 kernel_head.o:
 	as -32 kernel.S -o kernel_head.o
 kernel.o: kernel_head.o
-	gcc -c kernel.c -o kernel.o -std=gnu99 -ffreestanding -O2 -Wall -Wextra -m32
+	gcc -c kernel.c -o kernel.o -std=gnu99 -ffreestanding -fno-pie -O0 -Wall -Wextra -m32
 kernel.bin: kernel.o
-	gcc -T kernel.ld -o kernel.bin -ffreestanding -O2 -nostdlib kernel_head.o kernel.o -lgcc -m32
-
+	gcc -T kernel.ld -o kernel.bin -ffreestanding -fno-pie -O0 -nostdlib kernel_head.o kernel.o -lgcc -m32
+debug: kernel.bin
+	objdump -lSdx kernel.bin > kernel.lst
 run: kernel.bin
 	qemu-system-i386 -kernel kernel.bin
 clean:
-	rm kernel.o kernel.bin kernel_head.o
+	rm *.o *.bin *.lst
 


### PR DESCRIPTION
Without -fno-pie flag, this: __x86.get_pc_thunk.ax is getting
generated in the executable which is undesirable.

Changing O level to 0 for better debuggability.